### PR TITLE
OpenNewTab: Support Vivaldi

### DIFF
--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -69,11 +69,10 @@ interface Navigator {
   } | null;
 }
 
-// We have to extend the WebExtension definition of Tab to include the optional vivExtData key so
-// that we can check for it to identify the Vivaldi browser.
+// This is used to identify the Vivaldi browser.
 declare namespace browser.tabs {
   export interface Tab {
-    vivExtData?: typeof Object | undefined;
+    vivExtData?: unknown;
   }
 }
 

--- a/@types/globals.d.ts
+++ b/@types/globals.d.ts
@@ -69,6 +69,14 @@ interface Navigator {
   } | null;
 }
 
+// We have to extend the WebExtension definition of Tab to include the optional vivExtData key so
+// that we can check for it to identify the Vivaldi browser.
+declare namespace browser.tabs {
+  export interface Tab {
+    vivExtData?: typeof Object | undefined;
+  }
+}
+
 interface ShadowRoot {
   elementFromPoint: Document["elementFromPoint"];
   elementsFromPoint: Document["elementsFromPoint"];

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -2322,6 +2322,7 @@ export default class BackgroundProgram {
   }
 }
 
+// Copied from: https://stackoverflow.com/a/77047611
 async function getChromiumVariant(): Promise<ChromiumVariant> {
   const tabs = await browser.tabs.query({
     active: true,

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -1215,8 +1215,8 @@ export default class BackgroundProgram {
         url
       );
     } else if (BROWSER === "chrome") {
-      getChromiumVariant()
-        .then((chromiumVariant) => {
+      fireAndForget(
+        getChromiumVariant().then((chromiumVariant) => {
           this.sendWorkerMessage(
             {
               type: "OpenNewTab",
@@ -1226,10 +1226,9 @@ export default class BackgroundProgram {
             },
             { tabId, frameId: TOP_FRAME_ID }
           );
-        })
-        .catch((err) => {
-          log("log", "BackgroundProgram#openNewTab", url, err);
-        });
+        }),
+        "BackgroundProgram#openNewTab->getChromiumVariant"
+      );
     } else {
       fireAndForget(
         browser.tabs

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -2067,10 +2067,10 @@ export default class BackgroundProgram {
     const mac = info.os === "mac";
     const defaults = getDefaults({ mac });
     const rawOptions = await getRawOptions();
-    const chromiumVariant = await this.getChromiumVariant();
     const defaulted = { ...flattenOptions(defaults), ...rawOptions };
     const [unflattened, map] = unflattenOptions(defaulted);
     const options = decode(Options, unflattened, map);
+    const chromiumVariant = await getChromiumVariant();
 
     log("log", "BackgroundProgram#updateOptions", {
       defaults,
@@ -2091,17 +2091,6 @@ export default class BackgroundProgram {
     };
 
     log.level = options.logLevel;
-  }
-
-  async getChromiumVariant(): Promise<string> {
-    if (BROWSER !== "chrome") {
-      return "";
-    }
-    const tabs = await browser.tabs.query({
-      active: true,
-      currentWindow: true,
-    });
-    return tabs?.[0]?.vivExtData !== undefined ? "vivaldi" : "chrome";
   }
 
   async saveOptions(partialOptions: PartialOptions): Promise<void> {
@@ -2329,6 +2318,17 @@ export default class BackgroundProgram {
       }
     }
   }
+}
+
+async function getChromiumVariant(): Promise<string> {
+  if (BROWSER !== "chrome") {
+    return "";
+  }
+  const tabs = await browser.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  return tabs?.[0]?.vivExtData !== undefined ? "vivaldi" : "chrome";
 }
 
 function makeEmptyTabState(tabId: number | undefined): TabState {

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -2328,7 +2328,7 @@ async function getChromiumVariant(): Promise<ChromiumVariant> {
     active: true,
     currentWindow: true,
   });
-  return tabs?.[0]?.vivExtData !== undefined ? "vivaldi" : "chrome";
+  return tabs[0]?.vivExtData !== undefined ? "vivaldi" : "chrome";
 }
 
 function makeEmptyTabState(tabId: number | undefined): TabState {

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -193,6 +193,7 @@ export default class BackgroundProgram {
 
   constructor() {
     const mac = false;
+    const chromiumVariant = "";
     const defaults = getDefaults({ mac });
     this.options = {
       defaults,
@@ -200,6 +201,7 @@ export default class BackgroundProgram {
       raw: {},
       errors: [],
       mac,
+      chromiumVariant,
     };
   }
 
@@ -1219,6 +1221,7 @@ export default class BackgroundProgram {
           type: "OpenNewTab",
           url,
           foreground,
+          chromiumVariant: this.options.chromiumVariant,
         },
         { tabId, frameId: TOP_FRAME_ID }
       );
@@ -2064,6 +2067,7 @@ export default class BackgroundProgram {
     const mac = info.os === "mac";
     const defaults = getDefaults({ mac });
     const rawOptions = await getRawOptions();
+    const chromiumVariant = await this.getChromiumVariant();
     const defaulted = { ...flattenOptions(defaults), ...rawOptions };
     const [unflattened, map] = unflattenOptions(defaulted);
     const options = decode(Options, unflattened, map);
@@ -2083,9 +2087,21 @@ export default class BackgroundProgram {
       raw: rawOptions,
       errors: [],
       mac,
+      chromiumVariant,
     };
 
     log.level = options.logLevel;
+  }
+
+  async getChromiumVariant(): Promise<string> {
+    if (BROWSER !== "chrome") {
+      return "";
+    }
+    const tabs = await browser.tabs.query({
+      active: true,
+      currentWindow: true,
+    });
+    return tabs?.[0]?.vivExtData !== undefined ? "vivaldi" : "chrome";
   }
 
   async saveOptions(partialOptions: PartialOptions): Promise<void> {

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -2323,9 +2323,6 @@ export default class BackgroundProgram {
 }
 
 async function getChromiumVariant(): Promise<ChromiumVariant> {
-  if (BROWSER !== "chrome") {
-    return "";
-  }
   const tabs = await browser.tabs.query({
     active: true,
     currentWindow: true,

--- a/src/background/Program.ts
+++ b/src/background/Program.ts
@@ -45,6 +45,7 @@ import type {
   ToWorker,
 } from "../shared/messages";
 import {
+  ChromiumVariant,
   diffOptions,
   flattenOptions,
   getDefaults,
@@ -2320,7 +2321,7 @@ export default class BackgroundProgram {
   }
 }
 
-async function getChromiumVariant(): Promise<string> {
+async function getChromiumVariant(): Promise<ChromiumVariant> {
   if (BROWSER !== "chrome") {
     return "";
   }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -12,7 +12,7 @@ import type {
   NormalizedKeypress,
 } from "./keyboard";
 import type { Box, LogLevel } from "./main";
-import type { OptionsData, PartialOptions } from "./options";
+import type { ChromiumVariant, OptionsData, PartialOptions } from "./options";
 import type { Durations, Stats, TabsPerf } from "./perf";
 
 export type FromBackground =
@@ -129,7 +129,7 @@ export type ToWorker =
       type: "OpenNewTab";
       url: string;
       foreground: boolean;
-      chromiumVariant: string;
+      chromiumVariant: ChromiumVariant;
     }
   | {
       type: "ReverseSelection";

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -129,6 +129,7 @@ export type ToWorker =
       type: "OpenNewTab";
       url: string;
       foreground: boolean;
+      chromiumVariant: string;
     }
   | {
       type: "ReverseSelection";

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -104,7 +104,7 @@ export type FromWorker =
       type: "WorkerScriptAdded";
     };
 
-export type ChromiumVariant = "" | "chrome" | "vivaldi";
+export type ChromiumVariant = "chrome" | "vivaldi";
 
 export type ToWorker =
   | {

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -12,7 +12,7 @@ import type {
   NormalizedKeypress,
 } from "./keyboard";
 import type { Box, LogLevel } from "./main";
-import type { ChromiumVariant, OptionsData, PartialOptions } from "./options";
+import type { OptionsData, PartialOptions } from "./options";
 import type { Durations, Stats, TabsPerf } from "./perf";
 
 export type FromBackground =
@@ -103,6 +103,8 @@ export type FromWorker =
   | {
       type: "WorkerScriptAdded";
     };
+
+export type ChromiumVariant = "" | "chrome" | "vivaldi";
 
 export type ToWorker =
   | {

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -27,13 +27,15 @@ import {
   UnsignedInt,
 } from "./main";
 
+export type ChromiumVariant = "" | "chrome" | "vivaldi";
+
 export type OptionsData = {
   values: Options;
   defaults: Options;
   raw: FlatOptions;
   errors: Array<string>;
   mac: boolean;
-  chromiumVariant: string;
+  chromiumVariant: ChromiumVariant;
 };
 
 export type Options = ReturnType<typeof Options>;

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -27,15 +27,12 @@ import {
   UnsignedInt,
 } from "./main";
 
-export type ChromiumVariant = "" | "chrome" | "vivaldi";
-
 export type OptionsData = {
   values: Options;
   defaults: Options;
   raw: FlatOptions;
   errors: Array<string>;
   mac: boolean;
-  chromiumVariant: ChromiumVariant;
 };
 
 export type Options = ReturnType<typeof Options>;

--- a/src/shared/options.ts
+++ b/src/shared/options.ts
@@ -33,6 +33,7 @@ export type OptionsData = {
   raw: FlatOptions;
   errors: Array<string>;
   mac: boolean;
+  chromiumVariant: string;
 };
 
 export type Options = ReturnType<typeof Options>;

--- a/src/worker/Program.ts
+++ b/src/worker/Program.ts
@@ -458,12 +458,13 @@ export default class WorkerProgram {
       // This technique does not seem to work in Firefox, but it's not needed
       // there anyway (see background/Program.ts).
       case "OpenNewTab": {
-        const { url, foreground } = message;
+        const { url, foreground, chromiumVariant } = message;
         const link = document.createElement("a");
+        const ctrlKey = chromiumVariant !== "vivaldi";
         link.href = url;
         link.dispatchEvent(
           new MouseEvent("click", {
-            ctrlKey: true,
+            ctrlKey,
             metaKey: true,
             shiftKey: foreground,
           })

--- a/src/worker/Program.ts
+++ b/src/worker/Program.ts
@@ -460,7 +460,7 @@ export default class WorkerProgram {
       case "OpenNewTab": {
         const { url, foreground, chromiumVariant } = message;
         const link = document.createElement("a");
-        const ctrlKey = chromiumVariant !== "vivaldi";
+        const ctrlKey = chromiumVariant !== "vivaldi" || !foreground;
         link.href = url;
         link.dispatchEvent(
           new MouseEvent("click", {

--- a/src/worker/Program.ts
+++ b/src/worker/Program.ts
@@ -30,6 +30,7 @@ import {
   walkTextNodes,
 } from "../shared/main";
 import type {
+  ChromiumVariant,
   FromBackground,
   FromWorker,
   ToBackground,
@@ -458,16 +459,10 @@ export default class WorkerProgram {
       // This technique does not seem to work in Firefox, but it's not needed
       // there anyway (see background/Program.ts).
       case "OpenNewTab": {
-        const { url, foreground, chromiumVariant } = message;
         const link = document.createElement("a");
-        const ctrlKey = chromiumVariant !== "vivaldi" || !foreground;
-        link.href = url;
+        link.href = message.url;
         link.dispatchEvent(
-          new MouseEvent("click", {
-            ctrlKey,
-            metaKey: true,
-            shiftKey: foreground,
-          })
+          new MouseEvent("click", getOpenNewTabModifiers(message))
         );
         break;
       }
@@ -1862,4 +1857,27 @@ function temporarilySetFilter(
       }
     },
   };
+}
+
+function getOpenNewTabModifiers({
+  chromiumVariant,
+  foreground,
+}: {
+  chromiumVariant: ChromiumVariant;
+  foreground: boolean;
+}): MouseEventInit {
+  switch (chromiumVariant) {
+    case "chrome":
+      return {
+        ctrlKey: true,
+        metaKey: true,
+        shiftKey: foreground,
+      };
+    case "vivaldi":
+      return {
+        ctrlKey: !foreground,
+        metaKey: true,
+        shiftKey: foreground,
+      };
+  }
 }


### PR DESCRIPTION
Vivaldi is a Chromium-based browser that has decided to present itself as Chrome but that differs from Chrome in a number of ways. In particular, Vivaldi uses shift+click to open a link in a new foreground tab and ctrl+shift+click to open a link in a new foreground *window*.

This adds support to detect Vivaldi and change the simulated click that the "OpenNewTab" command executes accordingly. Per [this SO answer][1], we must use the extension tabs API to identify Vivaldi, and this requires some extra work that we'd prefer to do just once, so we do it as part of the options setup on the background Program. Additionally, the check requires accessing a property that the WebExtension definition of `browser.tabs.Tab` doesn't know about, so we have to extend that interface in @types.globals.d.ts for this special case.

[1]: https://stackoverflow.com/a/77047611

Closes https://github.com/lydell/LinkHints/issues/39